### PR TITLE
Add a section on how to configure Heap Analytics package

### DIFF
--- a/content/Elegant - Pelican Theme/stat-counter-google-analytics.md
+++ b/content/Elegant - Pelican Theme/stat-counter-google-analytics.md
@@ -62,9 +62,9 @@ That's it. Elegant will take care of the rest.
 Heap
 ----
 
-From your Heap console, navigate to Settings->Projects. You need to copy the
-Project ID you want to log to. Set `HEAP_ANALYTICS` in your configuration with
-this value.
+From your [Heap console](https://heapanalytics.com/app/account), navigate to
+Settings->Projects. You need to copy the Project ID you want to log to.
+Set `HEAP_ANALYTICS` in your configuration with this value.
 
     :::python
     HEAP_ANALYTICS = 1234567890

--- a/content/Elegant - Pelican Theme/stat-counter-google-analytics.md
+++ b/content/Elegant - Pelican Theme/stat-counter-google-analytics.md
@@ -4,16 +4,16 @@ Category: Elegant - Pelican Theme
 Date: 2013-11-11 23:05
 Slug: how-to-use-statcounter-and-google-analytics
 Disqus_identifier: 4kv80xq-how-to-use-statcounter-and-google-analytics
-Subtitle: 
+Subtitle:
 Summary: Elegant Pelican theme supports StatCounter and Google Analytics out of
     the box. This articles describes how to set them up.
-Keywords: 
+Keywords:
 
 [TOC]
 
 Elegant has support for popular web tracking services,
-[StatCounter](http://statcounter.com/) and [Google
-Analytics](http://www.google.com/analytics/).
+[StatCounter](http://statcounter.com/), [Google
+Analytics](http://www.google.com/analytics/) and [Heap](https://heapanalytics.com/).
 
 You have to put web property ID assigned to you by the these services, in your
 configuration to use the tracking code.
@@ -59,3 +59,14 @@ Set `GOOGLE_ANALYTICS` variable to it in your configuration.
 
 That's it. Elegant will take care of the rest.
 
+Heap
+----
+
+From your Heap console, navigate to Settings->Projects. You need to copy the
+Project ID you want to log to. Set `HEAP_ANALYTICS` in your configuration with
+this value.
+
+    :::python
+    HEAP_ANALYTICS = 1234567890
+
+Elegant will take care of the rest once that value is added.


### PR DESCRIPTION
This adds a section to the documentation on how to enable Heap analytics which is added in https://github.com/Pelican-Elegant/elegant/pull/184