### PR TITLE
Remove apostrophes from slug metadata

### DIFF
--- a/content/Elegant - Pelican Theme/travis-ci-and-doc-website.md
+++ b/content/Elegant - Pelican Theme/travis-ci-and-doc-website.md
@@ -7,8 +7,8 @@ date: 2018-12-07 16:00:47 +0100
 comments: true
 category: Development
 description:
-slug: 'travis-ci-and-doc-website'
-disqus_identifier: 'travis-ci-and-doc-website'
+slug: travis-ci-and-doc-website
+disqus_identifier: travis-ci-and-doc-website
 ---
 
 [TOC]

--- a/content/Elegant - Pelican Theme/travis-to-trigger-build-in-another-repo.md
+++ b/content/Elegant - Pelican Theme/travis-to-trigger-build-in-another-repo.md
@@ -7,8 +7,8 @@ date: 2018-12-11 21:49:47 +0100
 comments: true
 category: Development
 description:
-slug: 'travis-to-trigger-build-in-another-repo'
-disqus_identifier: 'travis-to-trigger-build-in-another-repo'
+slug: travis-to-trigger-build-in-another-repo
+disqus_identifier: travis-to-trigger-build-in-another-repo
 ---
 
 [TOC]


### PR DESCRIPTION
The apostrophes on these two articles was causing URLs to be generated with apostrophes (ie. https://pelican-elegant.github.io/'travis-to-trigger-build-in-another-repo' ).