### PR TITLE
Fixes warnings about static vs filename; Fixes missing article URL

### DIFF
--- a/content/Elegant - Pelican Theme/author-blurbs.md
+++ b/content/Elegant - Pelican Theme/author-blurbs.md
@@ -32,12 +32,9 @@ dictionary. If an unknown author appears, they will not receive a blurb.
 The article author is determined by the provided metadata in your content
 file. Valid values are:
 
-    - `author:` - This defines the *single* author of the article.
-    - `authors:` - This is a comma separated list of all article authors. Each
-    known author will get a blurb. Each unknown author will not get a blurb.
-    - Default author defined in your configuration file. If either of the two
-    metatags above are not used, the default author you configured will be
-    utilized. This author still requires an entry in the `AUTHORS` dictionary.
+- `author:` - This defines the *single* author of the article.
+- `authors:` - This is a comma separated list of all article authors. Each known author will get a blurb. Each unknown author will not get a blurb.
+- Default author defined in your configuration file. If either of the two metatags above are not used, the default author you configured will be utilized. This author still requires an entry in the `AUTHORS` dictionary.
 
 **Note:** If you define multiple authors, but use the `author:` metatag, a blurb
 will not be generated. This metatag is for a *single* author. The correct way to
@@ -48,4 +45,4 @@ This is an example of multiple authors using the following metatag value:
     :::python
     authors: Talha Mansoor, Milton Bradley
 
-![Author Blurb](|filename|/images/author-blurb.png)
+![Author Blurb]({static}/images/author-blurb.png)

--- a/content/Elegant - Pelican Theme/disqus-comments.md
+++ b/content/Elegant - Pelican Theme/disqus-comments.md
@@ -4,9 +4,9 @@ Category: Elegant - Pelican Theme
 Date: 2014-04-21 16:39
 Slug: how-to-use-disqus-comments-elegantly
 Disqus_identifier: 9jgwmy8-how-to-use-disqus-comments-elegantly
-Subtitle: 
+Subtitle:
 Summary: Elegant offers Disqus comments out of the box with few unique features
-Keywords: 
+Keywords:
 
 Pelican uses Disqus for comments. You have to set `DISQUS_SITENAME` to Disqus
 site name identifier in configuration to enable comments.
@@ -18,7 +18,7 @@ But that's not all. Elegant raises the notch up with following unique features.
 Instead of just throwing in comments form at the end of every article, Elegant
 offers you a way to write introductory text that would appear right before comments.
 
-![Introductory text to the comments](|filename|/images/elegant-theme_comments-introduction.png)
+![Introductory text to the comments]({static}/images/elegant-theme_comments-introduction.png)
 
 Set your message to `comments_intro` in the article metadata. You may also
 define `COMMENTS_INTRO` in Pelican configuration.  
@@ -45,4 +45,3 @@ the article URL.
 
 If you choose not to use `disqus_identifier`, Elegant passes article URL to
 Disqus.
-

--- a/content/Elegant - Pelican Theme/elegant-theme.md
+++ b/content/Elegant - Pelican Theme/elegant-theme.md
@@ -46,12 +46,12 @@ overwhelm your host server for every search query.
 
 Here is how the search result looks like
 
-![Search result for App Store](|filename|/images/elegant-theme_search-result.png)
+![Search result for App Store]({static}/images/elegant-theme_search-result.png)
 
 Search box is part of main navigation menu so that visitor can search from any
 page.
 
-![Search box](|filename|/images/elegant-theme_search-box.png)
+![Search box]({static}/images/elegant-theme_search-box.png)
 
 ## Live Filter for Tags
 
@@ -65,12 +65,12 @@ will automatically filter the list.
 For example, this is how my tags page looks like
 
 ![Tags view
-unfiltered](|filename|/images/elegant-theme_tags-live-filter-default.png)
+unfiltered]({static}/images/elegant-theme_tags-live-filter-default.png)
 
 As soon as I type "os", all other tags are filtered out
 
 ![Tags view filtered for
-"os"](|filename|/images/elegant-theme_tags-live-filter-filtered.png)
+"os"]({static}/images/elegant-theme_tags-live-filter-filtered.png)
 
 With live filter, your reader will have no difficulty in picking up his desired
 tag from the list, even if your site has hundreds of tags.
@@ -89,12 +89,12 @@ accordions](http://getbootstrap.com/2.3.2/javascript.html#collapse).
 Here is how categories appear collapsed
 
 ![Categories accordions
-collapsed](|filename|/images/elegant-theme_category-accordions-collapsed.png)
+collapsed]({static}/images/elegant-theme_category-accordions-collapsed.png)
 
 And this is how they appear uncollapsed
 
 ![Categories accordions
-uncollapsed](|filename|/images/elegant-theme_category-accordions-uncollapsed.png)
+uncollapsed]({static}/images/elegant-theme_category-accordions-uncollapsed.png)
 
 Did you notice that categories are listed in ascending alphabetical order and
 articles are sorted by their date in descending order?
@@ -105,7 +105,7 @@ This is the page that visitors see when they open your website. Your chance to
 make a good and lasting first impression. Most sites just display a list of
 recent posts. Elegant goes the extra mile. Check this out
 
-![Home Page Sample](|filename|/images/elegant-theme_home-page-features.png)
+![Home Page Sample]({static}/images/elegant-theme_home-page-features.png)
 
 You can see two sections here,
 
@@ -114,7 +114,7 @@ You can see two sections here,
 
 There is a third section below these two sections, "Recent articles"
 
-![Recent Articles Section](|filename|/images/elegant-theme_recent-posts.png)
+![Recent Articles Section]({static}/images/elegant-theme_recent-posts.png)
 
 ### About me
 
@@ -155,7 +155,7 @@ subscribe to your newsletter, above the fold, in the right section of every
 article. Increased visibility is said to increase number of subscribers.
 
 ![Mailchimp subscriber
-form](|filename|/images/elegant-theme_subscribe-form.png)
+form]({static}/images/elegant-theme_subscribe-form.png)
 
 You need to put your Mailchimp form action URL in `MAILCHIMP_FORM_ACTION` in
 your configuration file. You can also define `EMAIL_SUBSCRIPTION_LABEL`,
@@ -181,12 +181,12 @@ unhide the section by clicking on the comments section.
 This is how comments section appear
 
 ![Collapsed comments
-section](|filename|/images/elegant-theme_comments-section-collapsed.png)
+section]({static}/images/elegant-theme_comments-section-collapsed.png)
 
 It expands when reader clicks on it
 
 ![Uncollapsed comments
-section](|filename|/images/elegant-theme_comments-section-uncollapsed.png)
+section]({static}/images/elegant-theme_comments-section-uncollapsed.png)
 
 ## Articles Count with every Tag and Category
 
@@ -203,17 +203,17 @@ the same topic.
 Check out the screenshots,
 
 ![Count of articles in a category is displayed in
-superscript](|filename|/images/elegant-theme_category-superscript-count.png)
+superscript]({static}/images/elegant-theme_category-superscript-count.png)
 
 
 ![Count of articles that have been tagged is displayed in
-superscript](|filename|/images/elegant-theme_tag-superscript-count.png)
+superscript]({static}/images/elegant-theme_tag-superscript-count.png)
 
 ## Custom 404 Page
 
 Elegant has a custom Error 404 page for your readers.
 
-![Error 404 page](|filename|/images/elegant-theme_error-404-page.png)
+![Error 404 page]({static}/images/elegant-theme_error-404-page.png)
 
 ## Page Title
 
@@ -224,7 +224,7 @@ Article title · Site Name
 ```
 
 ![Article title is always visible in the
-tab](|filename|/images/elegant-theme_page-title.png)
+tab]({static}/images/elegant-theme_page-title.png)
 
 Some sites put site title first and article title later in the `<title>` tag.
 There is a problem with this approach.  When you open too many tabs, browser
@@ -260,7 +260,7 @@ subtitle support. Just define `subtitle` in your article's meta data and it
 will appear along with your title. Here is an example,
 
 ![Article subtitle
-example](|filename|/images/elegant-theme_article-subtitle.png)
+example]({static}/images/elegant-theme_article-subtitle.png)
 
 Article subtitle is displayed with the title in every list. To keep it visibly
 separate from title, subtitle is enclosed in `<small>` tag. When visible cue
@@ -268,7 +268,7 @@ cannot be used, like in the title attribute of html anchor tag `<a>`, a hyphen
 is inserted between them.
 
 ![Article title and subtitle separated with a
-hyphen](|filename|/images/elegant-theme_article-subtitle-hyphen.png)
+hyphen]({static}/images/elegant-theme_article-subtitle-hyphen.png)
 
 ***************************
 
@@ -308,4 +308,3 @@ There are two problem areas that I can think of,
 
 Besides these, there must be other bugs that I haven't noticed yet. I need your
 help to hunt them down and make them behave.
-

--- a/content/Elegant - Pelican Theme/misc-features.md
+++ b/content/Elegant - Pelican Theme/misc-features.md
@@ -18,14 +18,14 @@ Pelican powered blogs.
 You can put your license string in `SITE_LICENSE`. It will appear in the footer
 of every page of your site. Here is how license of my site looks like,
 
-![onCrashReboot site license](|filename|/images/elegant-theme_license.png)
+![onCrashReboot site license]({static}/images/elegant-theme_license.png)
 
 ## Site Subtitle
 
 You can also define `SITE_SUBTITLE`, it appears in the footer, before site
 license.
 
-![Site subtitle](|filename|/images/elegant-theme_site-subtitle.png)
+![Site subtitle]({static}/images/elegant-theme_site-subtitle.png)
 
 ## Web Safe Fonts
 

--- a/content/Elegant - Pelican Theme/modified-date.md
+++ b/content/Elegant - Pelican Theme/modified-date.md
@@ -14,7 +14,7 @@ date of the article by defining `modified` in your article metadata.
 
 This is how it is displayed in the side bar,
 
-![Modified Date](|filename|/images/elegant-theme_last-modified.png)
+![Modified Date]({static}/images/elegant-theme_last-modified.png)
 
 Pelican post [version
 3.3](https://github.com/getpelican/pelican/releases/tag/3.3.0) has a new

--- a/content/Elegant - Pelican Theme/multi-part-plugin.md
+++ b/content/Elegant - Pelican Theme/multi-part-plugin.md
@@ -20,7 +20,7 @@ To mark articles that belong to the same series, define `parts` metadata.
 Elegant shows the multi-part series in the sidebar.
 
 ![multi-part example in the
-sidebar](|filename|/images/elegant-theme_multi-part-sidebar.png)
+sidebar]({static}/images/elegant-theme_multi-part-sidebar.png)
 
 Articles are sorted by their date in ascending order. The oldest article is
 considered "Part 1" and so on.
@@ -32,7 +32,7 @@ Title attribute of html anchor tag `<a>` is set for each "Part" to its article
 title; it is displayed when user hovers over the link.
 
 ![multi-part example with title of the
-links](|filename|/images/elegant-theme_multi-part-title-attribute.png)
+links]({static}/images/elegant-theme_multi-part-title-attribute.png)
 
 As all other features, Elegant has some tricks up its sleeve.
 
@@ -48,7 +48,7 @@ in your articles metadata, like,
 
 And this will give you,
 
-![multi-part example with custom series title](|filename|/images/elegant-theme_multi-part-custom-label.png)
+![multi-part example with custom series title]({static}/images/elegant-theme_multi-part-custom-label.png)
 
 You have to make sure `series_title` metadata is set for every article in the
 series.

--- a/content/Elegant - Pelican Theme/previous-and-next-article.md
+++ b/content/Elegant - Pelican Theme/previous-and-next-article.md
@@ -16,7 +16,7 @@ plugin](https://github.com/getpelican/pelican-plugins/tree/master/neighbors) to
 show these navigational links.
 
 ![Show next and previous
-articles](|filename|/images/elegant-theme_previous-next-article.png)
+articles]({static}/images/elegant-theme_previous-next-article.png)
 
 Elegant shows newer article on the right hand side and older article on the
 left hand side at the bottom of every article.

--- a/content/Elegant - Pelican Theme/rss-feeds.md
+++ b/content/Elegant - Pelican Theme/rss-feeds.md
@@ -37,7 +37,7 @@ Extension](https://chrome.google.com/webstore/detail/rss-subscription-extensio/n
 
 Here is an example of my category feeds in Chrome.
 
-![Display RSS Feeds in Chrome](|filename|/images/rss-feeds-chrome-category-feeds.png)
+![Display RSS Feeds in Chrome]({static}/images/rss-feeds-chrome-category-feeds.png)
 
 These options make it redundant to have a separate RSS icon on the page.
 Elegant is all about a clean and minimal UI.
@@ -51,4 +51,4 @@ widget](how-to-display-your-social-media-profiles). Then add a tuple for RSS,
 
 Viola! You got yourself the RSS icon.
 
-![RSS Feeds icon in Social widget](|filename|/images/rss-feeds-icon-social-widget.png)
+![RSS Feeds icon in Social widget]({static}/images/rss-feeds-icon-social-widget.png)

--- a/content/Elegant - Pelican Theme/share-post-plugin.md
+++ b/content/Elegant - Pelican Theme/share-post-plugin.md
@@ -44,7 +44,7 @@ configuration,
 
 And viola!
 
-![Share Post plugin in Elegant](|filename|/images/elegant-theme-share-post-plugin.png)
+![Share Post plugin in Elegant]({static}/images/elegant-theme-share-post-plugin.png)
 
 Like [rest of the Elegant](how-to-customize-elegant) you can customize this
 widget too.

--- a/content/Elegant - Pelican Theme/social-profiles-sidebar.md
+++ b/content/Elegant - Pelican Theme/social-profiles-sidebar.md
@@ -18,7 +18,7 @@ web too. Most social widgets are loud and obtrusive. Their colors and placement
 takes away readers' attention from the actual content.
 
 <img class="align-right" style="width: 262.0px; height: 140.0px;"
-src="|filename|/images/social-profiles-sidebar-default.png" alt="Social
+src="{static}/images/social-profiles-sidebar-default.png" alt="Social
 Profiles in the Sidebar" />
 
 Elegant understands the importance of readers engagement but it makes sure
@@ -29,11 +29,11 @@ media profile with an appropriate title attribute. Icons use muted color which
 changes when user hovers over them.
 
 <img class="align-right" style="width: 134.0px; height: 62.5px;"
-src="|filename|/images/social-profiles-sidebar-facebook.png" alt="Hover over
+src="{static}/images/social-profiles-sidebar-facebook.png" alt="Hover over
 Facebook icon in the sidebar" />
 
 <img class="align-right" style="width: 134.0px; height: 62.5px;"
-src="|filename|/images/social-profiles-sidebar-twitter.png" alt="Hover over
+src="{static}/images/social-profiles-sidebar-twitter.png" alt="Hover over
 Twitter icon in the sidebar" />
 
 Elegant uses scalable vector icons from [Font

--- a/content/Elegant - Pelican Theme/table-of-contents.md
+++ b/content/Elegant - Pelican Theme/table-of-contents.md
@@ -65,7 +65,7 @@ This will generate
 [permalinks](https://github.com/waylan/Python-Markdown/pull/252) for every
 heading. Elegant keeps them hidden until user hovers over the heading.
 
-![Permalinks example using Markdown](|filename|/images/elegant-theme-toc-permalinks.png)
+![Permalinks example using Markdown]({static}/images/elegant-theme-toc-permalinks.png)
 
 # reStructuredText Format
 

--- a/content/Elegant - Pelican Theme/travis-to-trigger-build-in-another-repo.md
+++ b/content/Elegant - Pelican Theme/travis-to-trigger-build-in-another-repo.md
@@ -15,7 +15,7 @@ disqus_identifier: travis-to-trigger-build-in-another-repo
 
 # Introduction
 
-After setting up [build automation]({filename}2018-12-07-elegant-website-ci.md) we also wanted it not to happen only when updating the `documentation` repository.
+After setting up [build automation]({filename}travis-ci-and-doc-website.md) we also wanted it not to happen only when updating the `documentation` repository.
 
 Besides hosting documentation, Elegant website also serves as a live demo of the current release. This meant, the website should be regenerated and updated every time when a documented is added or edited, and also when Elegant theme is updated.
 
@@ -48,7 +48,7 @@ before_install:
 - mkdir -p tests/themes/elegant
 - mv templates tests/themes/elegant/
 - mv static tests/themes/elegant/
-- cd tests && peru sync 
+- cd tests && peru sync
 
 script:
 - pelican content/ -o output/
@@ -76,34 +76,34 @@ var Travis = require('travis-ci');
 var repo = "Pelican-Elegant/documentation";
 
 var travis = new Travis({
-	version: '2.0.0'
+    version: '2.0.0'
 });
 
 travis.authenticate({
 
-	// available through Travis CI
-	// see: http://kamranicus.com/blog/2015/02/26/continuous-deployment-with-travis-ci/
-	github_token: process.env.TRATOKEN
+    // available through Travis CI
+    // see: http://kamranicus.com/blog/2015/02/26/continuous-deployment-with-travis-ci/
+    github_token: process.env.TRATOKEN
 
 }, function (err, res) {
-	if (err) {
-		return console.error(err);
-	}
+    if (err) {
+        return console.error(err);
+    }
 
-	travis.repos(repo.split('/')[0], repo.split('/')[1]).builds.get(function (err, res) {
-		if (err) {
-			return console.error(err);
-		}
+    travis.repos(repo.split('/')[0], repo.split('/')[1]).builds.get(function (err, res) {
+        if (err) {
+            return console.error(err);
+        }
 
-		travis.requests.post({
-			build_id: res.builds[0].id
-		}, function (err, res) {
-			if (err) {
-				return console.error(err);
-			}
-			console.log(res.flash[0].notice);
-		});
-	});
+        travis.requests.post({
+            build_id: res.builds[0].id
+        }, function (err, res) {
+            if (err) {
+                return console.error(err);
+            }
+            console.log(res.flash[0].notice);
+        });
+    });
 });
 ```
 


### PR DESCRIPTION
This cleans up multiple warnings "{filename} used for linking staticcontent [...]. Use {static} instead"

Also fixes bullet points on `author-blurbs.md` that were made into a code block. Fixes broken link in `travis-to-trigger-build-in-another-repo.md`