### PR TITLE
Use beautifulsoup4 instead of dummy package bs4

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ misspellings
 pelican
 peru
 webassets
-bs4
+beautifulsoup4
 markdown
 cssmin
 ghp-import


### PR DESCRIPTION
bs4 is a dummy package that just redirects to beautifulsoup4. We should skip that redirect and use beautifulsoup4 directly.

The bs4 description implies that using bs4 is a mistake (though will still end up with beautifulsoup4 as expected)

https://pypi.org/project/bs4/